### PR TITLE
Fixed assign params to not attr_accessor attributes

### DIFF
--- a/lib/params_for/base.rb
+++ b/lib/params_for/base.rb
@@ -54,7 +54,7 @@ module ParamsFor
     #
     # @return [Boolean]
     def attribute?(key)
-      self.class.instance_methods.include? key.to_sym
+      self.class.attributes.include? key.to_sym
     end
 
     # Return the attributes of the validator filtered by


### PR DESCRIPTION
Fix assign params to any instance_method not defined in attribute accessor
